### PR TITLE
non-ascii characters (like "é") in filename or parameters crash on gecko sendAsBinary() in HTML 5 handler

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -444,14 +444,16 @@
 								multipartBlob += dashdash + boundary + crlf +
 									'Content-Disposition: form-data; name="' + name + '"' + crlf + crlf;
 
+								value = unescape(encodeURIComponent(value));
 								multipartBlob += value + crlf;
 							});
 
 							mimeType = plupload.mimeTypes[file.name.replace(/^.+\.([^.]+)/, '$1')] || 'application/octet-stream';
+							var filename = unescape(encodeURIComponent(file.name));
 
 							// Build RFC2388 blob
 							multipartBlob += dashdash + boundary + crlf +
-								'Content-Disposition: form-data; name="' + up.settings.file_data_name + '"; filename="' + file.name + '"' + crlf +
+								'Content-Disposition: form-data; name="' + up.settings.file_data_name + '"; filename="' + filename + '"' + crlf +
 								'Content-Type: ' + mimeType + crlf + crlf +
 								chunkBlob + crlf +
 								dashdash + boundary + dashdash + crlf;


### PR DESCRIPTION
This is a patch for issue #119, #104 and #92
