### PR TITLE
Calls to window.setTimeout are not specifying a time to wait.

### DIFF
--- a/src/javascript/plupload.js
+++ b/src/javascript/plupload.js
@@ -823,7 +823,7 @@
 						delay(function() {
 							self.trigger("QueueChanged");
 							self.refresh();
-						});
+						}, 1);
 					} else {
 						return false; // Stop the FilesAdded event from immediate propagation
 					}
@@ -866,7 +866,7 @@
 						// since other custom listeners might want to stop the queue
 						delay(function() {
 							uploadNext.call(self);
-						});
+						}, 1);
 					}
 				});
 
@@ -879,7 +879,7 @@
 					// since other custom listeners might want to stop the queue
 					delay(function() {
 						uploadNext.call(self);
-					});
+					}, 1);
 				});
 
 				// Setup runtimeList


### PR DESCRIPTION
In plupload.js there are three calls to windows.setTimeout that do not specify the required second argument (time to wait in milliseconds).  Oddly the code seems to work in most browsers without the time argument, but it does cause problems when integrating with other JavaScript libraries that alias the setTimeout function.

The time to wait argument is expected according to all the documentation I've read (including as far back as IE5) and I think it should be fixed.
