### PR TITLE
Fix HTML5 upload on newer WebKit browsers (like Chrome 9)

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -29,6 +29,21 @@
 		}
 	}
 
+	function readFileAsBinary(file, callback) {
+		var reader;
+
+		// Use FileReader if it's available
+		if ("FileReader" in window) {
+			reader = new FileReader();
+			reader.readAsBinaryString(file);
+			reader.onload = function() {
+				callback(reader.result);
+			};
+		} else {
+			return callback(file.getAsBinary());
+		}
+	}
+
 	function scaleImage(image_file, max_width, max_height, mime, callback) {
 		var canvas, context, img, scale;
 
@@ -602,11 +617,11 @@
 								file.size = res.data.length;
 								sendBinaryBlob(res.data);
 							} else {
-								sendBinaryBlob(nativeFile.getAsBinary());
+								readFileAsBinary(nativeFile, sendBinaryBlob);
 							}
 						});
 					} else {
-						sendBinaryBlob(nativeFile.getAsBinary());
+						readFileAsBinary(nativeFile, sendBinaryBlob);
 					}
 				} else {
 					sendBinaryBlob(nativeFile);


### PR DESCRIPTION
The HTML5 runtime upload on Chrome 9 currently fails with the error:

Uncaught TypeError: Object #<a File> has no method 'getAsBinary'
plupload.runtimes.Html5.plupload.addRuntime.init.uploader.bind.containerplupload.html5.js:609

unless image resizing is enabled. Modified the HTML5 runtime to use FileReader.readAsBinaryString() instead of File.getAsBinary() when available.
