### PR TITLE
Update the file list even when not using multiple queues

### DIFF
--- a/src/javascript/jquery.ui.plupload.js
+++ b/src/javascript/jquery.ui.plupload.js
@@ -391,9 +391,9 @@ $.widget("ui.plupload", {
 				$(self.start_button).button('enable');
 						
 				$('.plupload_header_content', self.element).removeClass('plupload_header_content_bw');
-					
-				self._updateFileList();
 			}
+
+			self._updateFileList();
 		}
 	},
 	


### PR DESCRIPTION
I'm not using multiple queues, and noticed that the list of files (hidden files of my form) was not being updated after the files were uploaded.

This patch fixes this issue.
