### PR TITLE
Support for *.* filter along with other filters

### DIFF
--- a/src/javascript/plupload.js
+++ b/src/javascript/plupload.js
@@ -978,7 +978,10 @@
 						
 						plupload.each(filters, function(filter) {
 							plupload.each(filter.extensions.split(/,/), function(ext) {
-								extensionsRegExp.push('\\.' + ext.replace(new RegExp('[' + ('/^$.*+?|()[]{}\\'.replace(/./g, '\\$&')) + ']', 'g'), '\\$&'));
+								if (ext == '*')
+									extensionsRegExp.push('.*');
+								else
+									extensionsRegExp.push('\\.' + ext.replace(new RegExp('[' + ('/^$.*+?|()[]{}\\'.replace(/./g, '\\$&')) + ']', 'g'), '\\$&'));
 							});
 						});
 


### PR DESCRIPTION
Support two filters, one with specific filename extension, and the other allowing all files, didn't work.

A concrete example: I have a upload for CSV files, but in case the user doesn't have her files correctly named, I want to offer her to select any file. The filters definition is this:

```
filters: [
    { title: "CSV files", extensions: "csv" },
    { title: "All files", extensions: "*"}
],
```

The extension \* works as expected in the file dialog (at least under Windows, Flash & Silverlight), but the regex which double checks the file doesn't accept the file.
