### PR TITLE
Preserve ICC color profiles in resized images in the HTML5 runtime

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -71,6 +71,10 @@
 
 			// Load image
 			img = new Image();
+			img.onerror = img.onabort = function() {
+				// Failed to load, the image may be invalid
+				callback({success : false});
+			};
 			img.onload = function() {
 				var width, height, percentage, APP1, APP2, parser;
 


### PR DESCRIPTION
This change extends the existing code in the HTML5 runtime for preserving EXIF data in resized JPEGs to also preserve ICC color profile data, if present. The ICC color profile is extracted from the APP2 segment(s) of the original image and re-added to the resized image. This allows applications that support color profiles (including browsers like Firefox and Safari) to apply appropriate color correction when displaying these images.

This change also fixes a couple of bugs in the existing EXIF parsing code, namely: the EXIF data was not being extracted if the APP1 segment followed an APP0 segment due to use of a wrong offset for reading the segment (this was evident when testing with the sample images from http://www.color.org/version4html.xalter); and, the EXIF data was not being extracted if a non-EXIF APP1 segment was present in the image before a EXIF APP1 segment.
