### PR TITLE
plupload was breaking styles on elements that already had position: absolute

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -245,7 +245,9 @@
 
 				if (uploader.settings.container) {
 					container = document.getElementById(uploader.settings.container);
-					container.style.position = 'relative';
+          if (plupload.getComputedStyle(container, 'position') === 'static') {
+            container.style.position = 'relative';
+          }
 				}
 
 				container.appendChild(inputContainer);
@@ -336,10 +338,12 @@
 							dropPos = plupload.getPos(dropElm, document.getElementById(uploader.settings.container));
 							dropSize = plupload.getSize(dropElm);
 							
-							plupload.extend(dropElm.style, {
-								position : 'relative'
-							});
-
+              if (plupload.getComputedStyle(dropElm, 'position') === 'static') {
+                plupload.extend(dropElm.style, {
+                  position : 'relative'
+                });
+              }
+              
 							plupload.extend(dropInputElm.style, {
 								position : 'absolute',
 								display : 'block',
@@ -399,9 +403,14 @@
 						}
 							
 						plupload.extend(browseButton.style, {
-							position : 'relative',
 							zIndex : pzIndex
 						});
+            
+            if (plupload.getComputedStyle(browseButton, 'position') === 'static') {
+              plupload.extend(browseButton.style, {
+                position : 'relative'
+              });
+            }
 											
 						plupload.extend(inputContainer.style, {
 							zIndex : pzIndex - 1

--- a/src/javascript/plupload.js
+++ b/src/javascript/plupload.js
@@ -605,7 +605,20 @@
 				return $1 === ' ' && $2 === ' ' ? ' ' : '';
 			});
 		},
-		
+    
+    /**
+		 * Returns a given computed style of a DOM element.
+		 *
+		 * @param {Object} obj DOM element like object.
+		 * @param {String} name Style you want to get from the DOM element
+		 */
+		getComputedStyle : function(obj, name) {
+      if (obj.currentStyle) {
+        return obj.currentStyle[name];
+      } else if (window.getComputedStyle) {
+        return window.getComputedStyle(obj, null)[name];
+      }
+		},
 
 		/**
 		 * Adds an event handler to the specified object and store reference to the handler


### PR DESCRIPTION
add plupload.getComputedStyle and use it to avoid forcing position: relative on elements that already act as capable offset parents.
I only used it for the HTML5 driver, might be good to use it elsewhere.
