### PR TITLE
Bug fix: Support JPEG images which only contain Exif headers

### DIFF
--- a/src/flash/plupload/src/com/mxi/image/Exif.as
+++ b/src/flash/plupload/src/com/mxi/image/Exif.as
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2011, Moxiecode Systems AB
+ * Released under GPL License.
+ *
+ * License: http://www.plupload.com/license
+ * Contributing: http://www.plupload.com/contributing
+ */
+
+package com.mxi.image 
+{
+	import com.mxi.BinaryReader;
+	import flash.external.ExternalInterface;
+	import flash.utils.ByteArray;
+
+	public class Exif 
+	{		
+		private const END_MARKERS:Array = [0xFFD9, 0xFFDA];
+		
+		protected var _br:BinaryReader;
+		
+		public function Exif(binData:ByteArray) 
+		{
+			_br = new BinaryReader;
+			_br.init(binData);
+		}
+		
+		public function info() : Object 
+		{
+			var idx:uint = 0, marker:uint, length:uint, limit:uint;
+			
+			limit = Math.min(1048576, _br.length);
+			
+			while (idx <= limit) {
+				marker = _br.SHORT(idx += 2);
+				if (marker == 0xFFE1) { // Exif header marker
+					try {
+						return getExifDimensions(idx); // try extract dimensions from exif
+					}
+					catch (e:Error)	{
+						return null;
+					}
+				}
+				else if (isEndMarker(marker)) { // encountered end marker
+					return null;
+				}
+				length = _br.SHORT(idx += 2);
+				idx += length - 2;			
+			}
+			
+			return null;
+		}
+		
+		private function getExifDimensions(start:uint) : Object
+		{
+			return {
+				height: getExifWidth(start),
+				width: getExifHeight(start)
+			};			
+		}
+		
+		private function getExifWidth(start:uint) : uint
+		{
+			return getExifTagValue(start, 0xA003);
+		}
+		
+		private function getExifHeight(start:uint) : uint
+		{
+			return getExifTagValue(start, 0xA002);
+		}
+		
+		private function getExifTagValue(start:uint, token:uint) : uint
+		{
+			var idx:uint, marker:uint, length:uint, limit:uint, type:uint;
+			
+			idx = start;
+			
+			limit = Math.min(1048576, _br.length);
+			
+			while (idx <= limit) { // make sure we examine just enough data
+				marker = _br.SHORT(idx += 2);
+				
+				if (marker == token) {
+					type = _br.SHORT(idx + 2); // data type
+					
+					if (type == 3) { // 3 = short
+						return _br.SHORT(idx + 8);
+					}
+					else if (type == 4) { // 4 = long
+						return _br.LONG(idx + 8);
+					}
+					else { // unsupported type / invalid data
+						throw new Error("Unsupported type " + type);
+					}						
+				}
+			}
+			
+			throw new Error("Token " + token.toString(16) + " not found");
+		}
+		
+		private function isEndMarker(m:uint) : Boolean
+		{
+			return (END_MARKERS.indexOf(m) != -1);
+		}
+	}
+
+}

--- a/src/flash/plupload/src/com/mxi/image/Image.as
+++ b/src/flash/plupload/src/com/mxi/image/Image.as
@@ -86,6 +86,14 @@ package com.mxi.image
 			if (JPEG.test(_source)) {
 				var jpeg:JPEG = new JPEG(_source);
 				_info = jpeg.info();
+				
+				// if jpeg info failed then try extract data from exif headers
+				if (!_info)
+				{
+					var exif:Exif = new Exif(_source);
+					_info = exif.info();
+				}
+				
 				if (_info) {
 					_info['type'] = 'JPEG';
 				}			


### PR DESCRIPTION
Added basic Exif header parser which tries to extract image dimensions from Exif header if parsing the JFIF header failes for some reason. This seems to be problematic with some JPEG images created by digital cameras which do not include the JFIF header and only have the Exif header.
