### PR TITLE
Do not modify the quality setting when resizing

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -113,12 +113,10 @@
 							}
 						}
 						
-						if (resize['quality']) {
-							resize['quality'] /= 100;	
-							
+						if (resize['quality']) {							
 							// Try quality property first
 							try {
-								data = canvas.toDataURL(mime, resize['quality']);	
+								data = canvas.toDataURL(mime, resize['quality'] / 100);	
 							} catch (e) {
 								data = canvas.toDataURL(mime);	
 							}


### PR DESCRIPTION
Do not modify the quality setting when resizing. This fixes a bug where the quality was reduced by a factor of 100 after every upload.
