### PR TITLE
When restoring JPEG headers to a resized image, delete any existing headers

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -869,9 +869,18 @@
 				read.init(data);
 				
 				// Check if data is jpeg
-				if (read.SHORT(0) !== 0xFFD8) {
+				var jpegHeaders = new JPEG_Headers(data);
+				
+				if (!jpegHeaders['headers']) {
 					return false;
 				}	
+				
+				// Delete any existing headers that need to be replaced
+				for (var i = jpegHeaders['headers'].length; i > 0; i--) {
+					var hdr = jpegHeaders['headers'][i - 1];
+					read.SEGMENT(hdr.start, hdr.length, '')
+				}
+				jpegHeaders.purge();
 				
 				idx = read.SHORT(2) == 0xFFE0 ? 4 + read.SHORT(4) : 2;
 								


### PR DESCRIPTION
Currently when images are resized in the HTML5 runtime in Chrome 10 with a "quality" setting, EXIF data is not restored to the resized image. Note that ICC data is restored, and EXIF data is restored when the "quality" setting is not enabled.

The problem appears to be that when resizing the image while changing the quality, Chrome 10 adds an EXIF segment to the resized image. This EXIF segment does not contain the original metadata; it contains only dimension (ExifImageLength/Width) information. This existing EXIF segment prevents the original EXIF segment from being restored.

The solution presented here is, when restoring JPEG headers to a resized image, delete any existing headers that are present in the image before restoring the original headers.

Some browsers like Chrome may retain part of the header data in the resized image, so these retained headers need to be overwritten with the original data.
