### PR TITLE
Check for presence of JPEG headers before attempting to restore on resize

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -129,8 +129,8 @@
 					data = data.substring(data.indexOf('base64,') + 7);
 					data = atob(data);
 
-					// Restore JPEG headers
-					if (jpegHeaders['headers'] && jpegHeaders['headers'].length) {
+					// Restore JPEG headers if applicable
+					if (jpegHeaders && jpegHeaders['headers'] && jpegHeaders['headers'].length) {
 						data = jpegHeaders.restore(data);
 						jpegHeaders.purge(); // free memory
 					}


### PR DESCRIPTION
Upload with resize currently fails on PNG images. Check if jpegHeaders is initialized before trying to restore JPEG headers.
