### PR TITLE
allow BeforeUpload to cancel/pause the upload flow

### DIFF
--- a/src/javascript/plupload.js
+++ b/src/javascript/plupload.js
@@ -848,8 +848,9 @@
 					if (!file && files[i].status == plupload.QUEUED) {
 						file = files[i];
 						file.status = plupload.UPLOADING;
-						this.trigger("BeforeUpload", file);
-						this.trigger("UploadFile", file);
+						if (this.trigger("BeforeUpload", file)) {
+							this.trigger("UploadFile", file);
+						}
 					} else {
 						count++;
 					}


### PR DESCRIPTION
This is a really small change and a big requirement for my current project: we are uploading a bunch of files to a remote server (using cross-domain XHR) but each of these files needs to go with an individual OAuth signature for security reasons. 

Current implementation doesn't allow to asynchronously fetch that data from the server on demand so this 3 line change will allow anyone to do as we are doing on our project.

A rough use case (using jQuery) would be like this:

```
  beforeUpload: function(up, file) {
    $.ajax({
      url: '/signed/url/service',
      type: 'GET',
      data: { foo: 'bar' }
      success: function (data) {
        up.settings.url = data;
        up.trigger('UploadFile', file);
      }
    });
    return false;
  }
```
