### PR TITLE
Ensure flash object can access setFileFilters method before calling it.

### DIFF
--- a/src/javascript/plupload.flash.js
+++ b/src/javascript/plupload.flash.js
@@ -348,9 +348,12 @@
 
 				uploader.bind("Refresh", function(up) {
 					var browseButton, browsePos, browseSize;
+          var flash = getFlashObj();
 
 					// Set file filters incase it has been changed dynamically
-					getFlashObj().setFileFilters(uploader.settings.filters, uploader.settings.multi_selection);
+          if (flash && flash.setFileFilters) {
+					  flash.setFileFilters(uploader.settings.filters, uploader.settings.multi_selection);
+          }
 
 					browseButton = document.getElementById(up.settings.browse_button);
 					if (browseButton) {


### PR DESCRIPTION
For whatever reason, plupload triggers a Refresh event when handling a
StateChanged event. Strangely, a final StateChanged event is triggered
AFTER the UploadComplete event. If client code uses the UploadComplete
event to hide the flash object's parent container and the StateChanged event triggers a
Refresh using the flash runtime, then without checking for the presence
of #setFileFilters we get an exception unless the parent container is
visible.
