### PR TITLE
Add mime type support for Photoshop PSD files

### DIFF
--- a/src/javascript/plupload.js
+++ b/src/javascript/plupload.js
@@ -58,6 +58,7 @@
 		"image/bmp,bmp," +
 		"image/gif,gif," +
 		"image/jpeg,jpeg jpg jpe," +
+		"image/photoshop,psd," +
 		"image/png,png," +
 		"image/svg+xml,svg svgz," +
 		"image/tiff,tiff tif," +


### PR DESCRIPTION
The need to upload .psd files came up for me in a project, seemed like a reasonable file type to support.
