### PR TITLE
UI Widget: max file count checks only current selection

### DIFF
--- a/src/javascript/jquery.ui.plupload/jquery.ui.plupload.js
+++ b/src/javascript/jquery.ui.plupload/jquery.ui.plupload.js
@@ -219,11 +219,12 @@ $.widget("ui.plupload", {
 		
 		// check if file count doesn't exceed the limit
 		if (self.options.max_file_count) {
-			uploader.bind('FilesAdded', function(up, files) {
-				var length = files.length, removed = [];
+			uploader.bind('FilesAdded', function(up, selectedFiles) {
+				var removed = [], selectedCount = selectedFiles.length;
+				var extraCount = up.files.length + selectedCount - self.options.max_file_count;
 				
-				if (length > self.options.max_file_count) {
-					removed = files.splice(self.options.max_file_count);
+				if (extraCount > 0) {
+					removed = selectedFiles.splice(selectedCount - extraCount, extraCount);
 					
 					up.trigger('Error', {
 						code : self.FILE_COUNT_ERROR,


### PR DESCRIPTION
If a max_file_count parameter is present, it limits the number of files allowed in one "browse" selection, but not the overall number of files. For example, if max_file_count is 5, the user can hit "Add files," add up to 5 files, hit "Add files" again, and add up to 5 more files (rinse, repeat).

This was unexpected behavior for me and several others on the forums, and I would imagine is against the common use-case for a file count limitation.
