### PR TITLE
Typo fix: 'to large'

### DIFF
--- a/src/javascript/i18n/ja.js
+++ b/src/javascript/i18n/ja.js
@@ -32,6 +32,6 @@ plupload.addI18n({
    'File: %f, size: %s, max file size: %m': 'ファイル: %f, サイズ: %s, 最大ファイルサイズ: %m',
    'Upload element accepts only %d file(s) at a time. Extra files were stripped.': 'アップロード可能なファイル数は %d です。余分なファイルは削除されました',
    'Upload URL might be wrong or doesn\'t exist': 'アップロード先の URL が存在しません',
-   'Error: File to large: ': 'エラー: サイズが大きすぎます: ',
+   'Error: File too large: ': 'エラー: サイズが大きすぎます: ',
    'Error: Invalid file extension: ': 'エラー: 拡張子が許可されていません: '
 });

--- a/src/javascript/i18n/lv.js
+++ b/src/javascript/i18n/lv.js
@@ -20,7 +20,7 @@ plupload.addI18n({
     'File: %f, size: %s, max file size: %m': 'Fails: %f, izmērs: %s, maksimālais faila izmērs: %m',
     'Upload element accepts only %d file(s) at a time. Extra files were stripped.': 'Iespējams ielādēt tikai %d failus vienā reizē. Atlikušie faili netika pievienoti',
     'Upload URL might be wrong or doesn\'t exist': 'Augšupielādes URL varētu būt nepareizs vai neeksistē',
-    'Error: File to large: ': 'Kļūda: Fails pārāk liels: ',
+    'Error: File too large: ': 'Kļūda: Fails pārāk liels: ',
     'Error: Invalid file extension: ': 'Kļūda: Nekorekts faila paplašinājums:',
     'File extension error.': 'Faila paplašinājuma kļūda.',
     'File size error.': 'Faila izmēra kļūda.',

--- a/src/javascript/i18n/pt-br.js
+++ b/src/javascript/i18n/pt-br.js
@@ -30,6 +30,6 @@ plupload.addI18n({
    'File: %f, size: %s, max file size: %m': 'Arquivo: %f, tamanho: %s, máximo: %m',
    'Upload element accepts only %d file(s) at a time. Extra files were stripped.': 'Só são aceitos %d arquivos por vez. O que passou disso foi descartado.',
    'Upload URL might be wrong or doesn\'t exist': 'URL de envio está errada ou não existe',
-   'Error: File to large: ': 'Erro: Arquivo muito grande: ',
+   'Error: File too large: ': 'Erro: Arquivo muito grande: ',
    'Error: Invalid file extension: ': 'Erro: Tipo de arquivo não permitido: '
 });

--- a/src/javascript/jquery.plupload.queue/jquery.plupload.queue.js
+++ b/src/javascript/jquery.plupload.queue/jquery.plupload.queue.js
@@ -271,7 +271,7 @@
 						}
 
 						if (err.code == plupload.FILE_SIZE_ERROR) {
-							alert(_("Error: File to large: ") + file.name);
+							alert(_("Error: File too large: ") + file.name);
 						}
 
 						if (err.code == plupload.FILE_EXTENSION_ERROR) {

--- a/src/javascript/plupload.js
+++ b/src/javascript/plupload.js
@@ -185,7 +185,7 @@
 		INIT_ERROR : -500,
 
 		/**
-		 * File size error. If the user selects a file that is to large it will be blocked and an error of this type will be triggered.
+		 * File size error. If the user selects a file that is too large it will be blocked and an error of this type will be triggered.
 		 *
 		 * @property FILE_SIZE_ERROR
 		 * @final


### PR DESCRIPTION
'File to large' was being displayed instead of 'File too large'
