### PR TITLE
Fix html5 upload of unresized images or other files in Chrome and Firefox

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -698,7 +698,12 @@
 				} else if (features.cantSendBlobInFormData && up.settings.chunk_size) {
 					readFileAsBinary(nativeFile, sendBinaryBlob); // preload in memory first
 				} else {
-					sendBinaryBlob(nativeFile); 
+					if ("FileReader" in window || nativeFile.getAsBinary) {
+						readFileAsBinary(nativeFile, sendBinaryBlob); // preload in memory first
+					} else {
+						// Apparently this works in older webkit browsers (?)
+						sendBinaryBlob(nativeFile); 
+					}
 				}
 			});
 			


### PR DESCRIPTION
With the latest changes to the master branch file upload fails in certain cases in Chrome and Firefox.  Under the following conditions file upload fails and the contents of any uploaded file is replaced with "[object File]"
- Chrome or Firefox is used.
- File to upload is not a jpg or png.
- Chunking is not used.

If the above conditions are met then the current code will use this call to upload:

```
sendBinaryBlob(nativeFile);
```

This pull request fixes the call by calling readFileAsBinary as long as the features required for that function exist in the browser.  Previously the sendBinaryBlob call was avoided by checking if features.jpgresize was true.  But the logic was changed significantly with the fixes for issue #320.

I'm not sure why sendBinaryBlob is used in the fashion noted above at all.  Although before the latest round of commits there was a comment on that line noting that it would work on "older Webkits, but fail on fresh ones".  Perhaps it is needed for older browsers, I've left the call in as the last alternative for that possible case.
