### PR TITLE
Fix for issue #356 - JSON serializer fails on null

### DIFF
--- a/src/javascript/plupload.silverlight.js
+++ b/src/javascript/plupload.silverlight.js
@@ -17,6 +17,11 @@
 	function jsonSerialize(obj) {
 		var value, type = typeof obj, isArray, i, key;
 
+		// Treat undefined as null
+		if (obj === undef || obj === null) {
+			return 'null';
+		}
+
 		// Encode strings
 		if (type === 'string') {
 			value = '\bb\tt\nn\ff\rr\""\'\'\\\\';
@@ -64,11 +69,6 @@
 			}
 
 			return value;
-		}
-
-		// Treat undefined as null
-		if (obj === undef) {
-			return 'null';
 		}
 
 		// Convert all other types to string


### PR DESCRIPTION
In IE8, when jsonSerialize() is called with a null value, an error is returned: 'length' is null or not an object.

How to reproduce:

x = null;
y = jsonSerialize(x);

This is the patch for issue #356.  Sorry for the duplicate submission.
