### PR TITLE
HTML5 uploading breaks under Safari 5.1 due to FileReader not being supported

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -487,7 +487,9 @@
 
 				function sendBinaryBlob(blob) {
 					var chunk = 0, loaded = 0,
-						fr = new FileReader, xhr = new XMLHttpRequest, upload = xhr.upload,
+						fr = ("FileReader" in window) ? new FileReader : null,
+						xhr = new XMLHttpRequest,
+						upload = xhr.upload
 						
 						// if file was preloaded as binary string, we should send it accordingly
 						shouldSendBinary = typeof(blob) === 'string';
@@ -694,7 +696,7 @@
 						}
 						
 						// workaround Gecko 2,5,6 FormData+Blob bug: https://bugzilla.mozilla.org/show_bug.cgi?id=649150
-						if (features.cantSendBlobInFormData && features.chunks && up.settings.chunk_size) { // basically if Gecko 2,5,6
+						if (fr && features.cantSendBlobInFormData && features.chunks && up.settings.chunk_size) { // basically if Gecko 2,5,6
 							fr.onload = function() {
 								shouldSendBinary = true;
 								prepareAndSend(fr.result);


### PR DESCRIPTION
Hi, this fix detects if FileReader is not supported in the current browser and bypasses it.

I've tested this with Safari 5.1 and Chrome 13 and it seems to perform flawlessly. Let me know what you think.
