### PR TITLE
Remove ambiguity when stopping html5 uploads

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -677,7 +677,7 @@
 
 
 						// File upload finished
-						if (file.status == plupload.DONE || file.status == plupload.FAILED || up.state == plupload.STOPPED) {
+						if (file.status == plupload.DONE || file.status == plupload.FAILED) {
 							return;
 						}
 


### PR DESCRIPTION
Currently there is an ambiguity in the upload queue when an html5 upload is stopped.  Specifically In plupload.js the stop() action will set the uploader's state to STOPPED, and reset any files that have a status of UPLOADING back to QUEUED.  In html5's UploadFile function there are two possible paths once the uploader is stopped.  It will either complete the current upload or, if you catch it early enough, it will not begin the actual upload.  But in both cases the file.status is initially set to UPLOADING.

If you wish to both stop the upload and clear the queue (for example with a cancel button), it is impossible to determine if a file that is currently in an UPLOADING state will actual complete the upload - or if it will return early without completing the upload.  And there is no notification if it returns without uploading.  This makes it impossible to determine when the upload has truly been stopped.

Essentially, with the html5 runtime there are 4 states for a successful upload: QUEUED, UPLOADPREP, UPLOADING and DONE.  But it seems needlessly complicated to deal with an UPLOADPREP state separately. And the last minute check has minimal impact on stopping the uploads any faster as the overwhelming majority of the time in the UploadingFile function is spent uploading the actual file.

This pull request removes the ambiguity by removing the check of the uploader's state in html5's UploadFile function.  Once a file is set to UPLOADING it will upload to completion and any calling routines can count on that to determine when the upload is truly cancelled and the last in-progress upload is complete.
