### PR TITLE
Calculate progress taking into account the resizing ratio

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -731,7 +731,10 @@
 						// If it was scaled send the scaled image if it failed then
 						// send the raw image and let the server do the scaling
 						if (res.success) {
+							// store original size and scaling ratio
+							file.native_size = file.size;
 							file.size = res.data.length;
+							file.scale_ratio = file.size / file.native_size;
 							sendBinaryBlob(res.data);
 						} else {
 							sendBinaryBlob(nativeFile); 

--- a/src/javascript/plupload.js
+++ b/src/javascript/plupload.js
@@ -910,8 +910,13 @@
 				file = files[i];
 
 				if (file.size !== undef) {
-					total.size += file.size;
-					total.loaded += file.loaded;
+					// check if we have a scaling ratio here (currently set by html5 only)
+					// if none... then go on with default progress calculation with value of '1'
+					if(! file.scale_ratio) file.scale_ratio = 1;
+					// Use ratio to calculate progress regarding *original* size of files
+					// See post http://www.plupload.com/punbb/viewtopic.php?pid=5745#p5745 for more info
+					total.size += Math.ceil(file.size / file.scale_ratio);
+					total.loaded += Math.ceil(file.loaded / file.scale_ratio);
 				} else {
 					total.size = undef;
 				}


### PR DESCRIPTION
When uploading files with html5 runtime and resize enabled, I found that the global progress was not accurate. It took into account the size uploaded after resize and divide it by the size before resize... which does make slow progress...

Also if you add new files on a queue which habe been already uploaded, same pb :
- Say you have uploaded 3 photos, for an original weight of 9Mo. Reduced to 300Ko
- You add one photo of 3Mo, here is your new percentage, less than 10% wheras you should be over 75% given your new picture is going to be resized as the previous...

Initial post on forum:
http://www.plupload.com/punbb/viewtopic.php?pid=5745#p5745
