### PR TITLE
fix Safari drag&drop functionality when cancelling dragover event in parent element

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -395,6 +395,11 @@
 									dropInputElm.parentNode.removeChild(dropInputElm);									
 								}, uploader.id);
 								
+								// avoid event propagation as Safari cancels the whole capability of dropping files if you are doing a preventDefault of this event on the document body
+								plupload.addEvent(dropInputElm, 'dragover', function(e) {
+									e.stopPropagation();
+								}, uploader.id);
+								
 								dropElm.appendChild(dropInputElm);
 							}
 


### PR DESCRIPTION
At least on Safari Windows, if you cancel the dragover event on any parent element of the droppable area (to prevent the browser from opening a file that was dropped outside of our designated area), then Safari completely ignores the drop action. (nothing happens at all)

This patch has been on our production code for at least 4 months so I would say it's quite safe for merging. Not sure if anyone should actually depend on this event bubbling up on the DOM, we don't use the built-in queue plugin so let me know if this patch is no good.
