### PR TITLE
fixed issue #495: IE9 plupload.getPos returns wrong coordinates

### DIFF
--- a/src/javascript/plupload.js
+++ b/src/javascript/plupload.js
@@ -482,7 +482,7 @@
 			}
 
 			// Use getBoundingClientRect on IE 6 and IE 7 but not on IE 8 in standards mode
-			if (node && node.getBoundingClientRect && (navigator.userAgent.indexOf('MSIE') > 0 && doc.documentMode !== 8)) {
+			if (node && node.getBoundingClientRect && ((navigator.userAgent.indexOf('MSIE') > 0) && (doc.documentMode < 8))) {
 				nodeRect = getIEPos(node);
 				rootRect = getIEPos(root);
 


### PR DESCRIPTION
In IE9 plupload.getPos runs the legacy function 'getIEPos' returning the wrong coordinates in this case.
