### PR TITLE
fixed issue #472: IE8, HTML4: mouse cursor type should be pointer

### DIFF
--- a/src/javascript/plupload.html4.js
+++ b/src/javascript/plupload.html4.js
@@ -118,7 +118,8 @@
 						width : '100%',
 						height : '100%',
 						opacity : 0,
-						fontSize: '99px' // force input element to be bigger then needed to occupy whole space
+						fontSize: '99px', // force input element to be bigger then needed to occupy whole space
+						cursor: 'pointer'
 					});
 					
 					plupload.extend(form.style, {


### PR DESCRIPTION
In IE8+ (not sure about the older ones) it is perfectly possible to change the cursor-style for a file input field. However, the HTML4 runtime does not take advantage of this so the default cursor is shown instead. The patch is quite simple.
