### PR TITLE
Fix for crash when destroying uploader right after init

### DIFF
--- a/src/javascript/plupload.flash.js
+++ b/src/javascript/plupload.flash.js
@@ -12,7 +12,7 @@
 /*global window:false, document:false, plupload:false, ActiveXObject:false, escape:false */
 
 (function(window, document, plupload, undef) {
-	var uploadInstances = {}, initialized = {}, destroyed = false;
+	var uploadInstances = {}, initialized = {};
 
 	function getFlashVersion() {
 		var version;
@@ -158,7 +158,8 @@
 			}
 
 			function waitLoad() {
-				if destroyed return;
+				if(initialized[uploader.id] == undefined) 
+					return;
 
 				// Wait for 5 sec
 				if (waitCount++ > 5000) {
@@ -175,6 +176,20 @@
 
 			// Fix IE memory leaks
 			browseButton = flashContainer = null;
+
+			uploader.bind("Destroy", function(up) {
+				var flashContainer;
+				
+				plupload.removeAllEvents(document.body, up.id);
+				
+				delete initialized[up.id];
+				delete uploadInstances[up.id];
+				
+				flashContainer = document.getElementById(up.id + '_flash_container');
+				if (flashContainer) {
+					container.removeChild(flashContainer);
+				}
+			});
 
 			// Wait for Flash to send init event
 			uploader.bind("Flash:Init", function() {	
@@ -403,22 +418,6 @@
 				
 				uploader.bind("DisableBrowse", function(up, disabled) {
 					getFlashObj().disableBrowse(disabled);
-				});
-			
-				
-				uploader.bind("Destroy", function(up) {
-					var flashContainer;
-					destroyed = true;
-					
-					plupload.removeAllEvents(document.body, up.id);
-					
-					delete initialized[up.id];
-					delete uploadInstances[up.id];
-					
-					flashContainer = document.getElementById(up.id + '_flash_container');
-					if (flashContainer) {
-						container.removeChild(flashContainer);
-					}
 				});
 							
 				callback({success : true});


### PR DESCRIPTION
When using plupload pages in javascript application, it often gets destroyed few seconds after it has been initialized. When this happens, plupload crashes after some time with an error caused by missing container (missing obj in getStyles, to be precise).
The problem seems to me to be the waitLoad function. When the pluploader is destroyed, the waitLoad function keeps waiting and calls the callback even after pluploader is destroyed.
My fix is to, first, move the destory logic into the first part of the code, so when the pluploader is destroyed the flash runtime handles it. Second, when waitLoad runs, I check if the pluploader is destroyed (initialized[uploaderId] is undefined) and if so aborts.

First fix was not working. Hope you like this one instead :)
