### PR TITLE
flash no initializing when container has no content

### DIFF
--- a/src/javascript/plupload.flash.js
+++ b/src/javascript/plupload.flash.js
@@ -122,6 +122,10 @@
 				if (plupload.getStyle(container, 'position') === 'static') {
 					container.style.position = 'relative';
 				}
+				if (container) {
+					container.style.minWidth = '1px';
+					container.style.minHeight = '1px';
+				}
 			}
 
 			container.appendChild(flashContainer);


### PR DESCRIPTION
e.g: in the events.html example, if we remove the style attribute and also the content from the container element, the flash fails to initialize in FF and Chrome as the height will be 0px. Setting min-height and min-width solves the problem.
