### PR TITLE
Fix: Flash Runtime doesn't load in Chrome on Windows and Linux (PluploadQueue)

### DIFF
--- a/src/javascript/plupload.flash.js
+++ b/src/javascript/plupload.flash.js
@@ -111,8 +111,7 @@
 				top : '0px',
 				background : uploader.settings.shim_bgcolor || 'transparent',
 				zIndex : 99999,
-				width : '100%',
-				height : '100%'
+				width : '100%'
 			});
 
 			flashContainer.className = 'plupload flash';


### PR DESCRIPTION
Related to/fixes issues: #532 #262  (and probably #276)

A container with no content and height 100% caused an inline style of "height:0" to be applied, which prevents the widget/queue from initing.
#532 fixes this issue by setting min-height and min width to 1px.

I fix this issue by not setting the height (letting it be auto). It seems that the heights are set to pixel values later on, so the "auto" assumed value gets overwritten.
