### PR TITLE
fixes issue #565

### DIFF
--- a/src/javascript/plupload.js
+++ b/src/javascript/plupload.js
@@ -482,7 +482,7 @@
 			}
 
 			// Use getBoundingClientRect on IE 6 and IE 7 but not on IE 8 in standards mode
-			if (node && node.getBoundingClientRect && ((navigator.userAgent.indexOf('MSIE') > 0) && (doc.documentMode < 8))) {
+			if (node && node.getBoundingClientRect && ((navigator.userAgent.indexOf('MSIE') > 0) && ((!doc.documentMode) || (doc.documentMode < 8)))) {
 				nodeRect = getIEPos(node);
 				rootRect = getIEPos(root);
 


### PR DESCRIPTION
the basic problem is that document.documentMode was introduced in ie8, so on ie7 or ie6 we compare `undefined < 8` which will be false.
i'm not sure if this is the most elegant solution, but it solves the problem.
