### PR TITLE
IE9 supports triggerDialog

### DIFF
--- a/src/javascript/plupload.html4.js
+++ b/src/javascript/plupload.html4.js
@@ -36,7 +36,7 @@
 				multipart: true,
 				
 				// WebKit and Gecko 2+ can trigger file dialog progrmmatically
-				triggerDialog: (plupload.ua.gecko && window.FormData || plupload.ua.webkit) 
+				triggerDialog: (plupload.ua.gecko && window.FormData || plupload.ua.webkit || /MSIE 9\.0/.test(navigator.appVersion)) 
 			};
 		},
 


### PR DESCRIPTION
Had a bug with the HTML4 uploader not working under IE9 due to relying on the triggerDialog functionality, which currently is only detects for Opera and Webkit.

Change updates it to detect for IE9 and enables triggerDialog under the HTML4 uploader. Tested and it didn't seem to break anything as far as I can tell.
