### PR TITLE
pass errors in the http response to error handler

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -556,7 +556,8 @@
 											code : plupload.HTTP_ERROR,
 											message : plupload.translate('HTTP Error.'),
 											file : file,
-											status : httpStatus
+											status : httpStatus,
+											response: xhr.responseText
 										});
 									} else {
 										// Handle chunk response


### PR DESCRIPTION
If there are specific validation errors on the 
image (file size, dimensions, etc...) then you
need to be able to report those to the user.
