### PR TITLE
Fix for Issue #605 (HTML5 input stacking in dialogs) - updated pull

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -197,8 +197,8 @@
 				chunks: sliceSupport,
 				// Safari on Windows has problems when selecting multiple files
 				multi_selection: !(plupload.ua.safari && plupload.ua.windows),
-				// Gecko 2+ can trigger file dialog programatically
-				triggerDialog: plupload.ua.gecko && window.FormData
+				// WebKit and Gecko 2+ can trigger file dialog progrmmatically
+				triggerDialog: (plupload.ua.gecko && window.FormData || plupload.ua.webkit)
 			};
 		},
 
@@ -465,10 +465,7 @@
 							});
 						}
 						
-						zIndex = parseInt(plupload.getStyle(browseButton, 'zIndex'), 10);
-						if (isNaN(zIndex)) {
-							zIndex = 0;
-						}						
+						zIndex = plupload.getZindex(browseButton);
 							
 						plupload.extend(browseButton.style, {
 							zIndex : zIndex

--- a/src/javascript/plupload.js
+++ b/src/javascript/plupload.js
@@ -703,6 +703,27 @@
 		},
 
 		/**
+		 * returns the z-index of a DOM element, if explicitly set with a style or auto set value
+		 * by virtue of the element being a member of a stacking context (see: http://www.w3.org/TR/CSS2/visuren.html#z-index)
+		 *
+		 * This will handle a button in a dialog or tooltip where the maximizing of the z-index of
+		 * the buttons stacking context has already been handled.
+		 *
+		 * @param domElement
+		 * @return z index of root of stacking context or 0
+		 */
+		getZindex: function(domElement) {
+			var zIndex = NaN;
+			var contextRootElement = domElement;
+			while (contextRootElement != null && isNaN(zIndex)) {
+				zIndex = parseInt(plupload.getStyle(contextRootElement, 'zIndex'), 10);
+				contextRootElement = contextRootElement.parentNode;
+			}
+			return isNaN(zIndex) ? 0 : zIndex;
+		},
+
+
+		/**
 		 * Adds an event handler to the specified object and store reference to the handler
 		 * in objects internal Plupload registry (@see removeEvent).
 		 *


### PR DESCRIPTION
Hello, here's code and a couple of demo fiddles that fixes the issue #605 with z-index with WebKit browsers for HTML5. I've tested this code in Safari 5, Chrome 21. Firefox 12+. The two jsFiddles make it pretty easy to test on any other browsers you have.

I appreciate your considering the fix. I also have a fix in the works for the issue with IE9 positioning (issue with plupload.getPos() logic) when there is a min/max width set on body, if you are happy with this fix I'll share that one next.

Thanks!
Steve

Note the later commit, 3ba30df, reverts change 29126ae as that change was a temporary workaround to the real issue.  Commit 3ba30df is the actual fix.
