### PR TITLE
html4 + Win7 IE9 Access Denied Security Error

### DIFF
--- a/src/javascript/plupload.html4.js
+++ b/src/javascript/plupload.html4.js
@@ -199,22 +199,24 @@
 						try {
 							el = n.contentWindow.document || n.contentDocument || window.frames[n.id].document;
 						} catch (ex) {
-							// Probably a permission denied error
-							up.trigger('Error', {
-								code : plupload.SECURITY_ERROR,
-								message : plupload.translate('Security error.'),
-								file : currentFile
-							});
+                                                        try{
+								// Probably a permission denied error
+								up.trigger('Error', {
+									code : plupload.SECURITY_ERROR,
+									message : plupload.translate('Security error.'),
+									file : currentFile
+								});
 
-							return;
-						} finally {
-							// Probably a permission denied error
-							up.trigger('Error', {
-								code : plupload.SECURITY_ERROR,
-								message : plupload.translate('Security error.')
-							});
+								return;
+							} catch (ex2) {
+								// Probably a permission denied error
+								up.trigger('Error', {
+									code : plupload.SECURITY_ERROR,
+									message : plupload.translate('Security error.')
+								});
 
-							return;
+								return;
+							}
 						}
 
 						// Get result


### PR DESCRIPTION
A security error was caused by the line "file: currentFile" in Win7 IE9. When the error happens in the catch block, it does not trigger the 'Error' handler. Add a finally without the file to ensure the error triggers the 'Error' handler.

Other users with similar issue and more info:
http://www.plupload.com/punbb/viewtopic.php?pid=394#p394
http://www.plupload.com/punbb/viewtopic.php?id=1793
