### PR TITLE
Fixed invalid json response format on error.

### DIFF
--- a/examples/upload.php
+++ b/examples/upload.php
@@ -17,6 +17,9 @@ header("Cache-Control: post-check=0, pre-check=0", false);
 header("Pragma: no-cache");
 header("Content-Type: application/json");
 
+// By default all responses are errors unless we get to the end and change to success response code.
+header("HTTP/1.1 500 Internal Server Error");
+
 // Settings
 $targetDir = ini_get("upload_tmp_dir") . DIRECTORY_SEPARATOR . "plupload";
 //$targetDir = 'uploads';
@@ -127,5 +130,6 @@ if (!$chunks || $chunk == $chunks - 1) {
 }
 
 
-// Return JSON-RPC response
+// Return Success JSON-RPC response
+header("HTTP/1.1 200 OK");
 die('{"jsonrpc" : "2.0", "result" : null, "id" : "id"}');


### PR DESCRIPTION
If there is a problem with the file handling the resulting error messages are output corrupting the JSON response sent to the browser I have added "@" to suppress these messages so the response from the PHP is valid JSON.

I have also added a Json mime-type header to the output as it's good practice.
