### PR TITLE
Enable drag-drop for IE10

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -524,6 +524,12 @@
 						return;
 					}
 
+					// Block browser default drag enter
+					plupload.addEvent(dropElm, 'dragenter', function(e) {
+						e.preventDefault();
+						e.stopPropagation();
+					}, uploader.id);
+
 					// Block browser default drag over
 					plupload.addEvent(dropElm, 'dragover', function(e) {
 						e.preventDefault();


### PR DESCRIPTION
Block the default 'dragenter' event so that drag-drop will work with IE10.
