### PR TITLE
Enable filtering by extension with html5 runtime (Chrome, IE10)

### DIFF
--- a/src/javascript/plupload.html5.js
+++ b/src/javascript/plupload.html5.js
@@ -385,6 +385,7 @@
 							break no_type_restriction;
 						}
 						
+						mimes.push('.' + ext[y]);
 						type = plupload.mimeTypes[ext[y]];
 
 						if (type && plupload.inArray(type, mimes) === -1) {


### PR DESCRIPTION
Escape the madness of mime types by adding support for filtering by file extension to the html5 runtime!

This is part of the W3C spec, as documented here:
http://www.w3.org/TR/2012/WD-html5-20121025/states-of-the-type-attribute.html#attr-input-accept

At the moment the only browsers I know of that supports filtering by extension are Chrome and IE10. But hopefully support for other browsers should be in the pipeline.
