### PR TITLE
success_action_status

### DIFF
--- a/examples/jquery/s3.php
+++ b/examples/jquery/s3.php
@@ -115,8 +115,7 @@ $(function() {
 			'key': '${filename}', // use filename as a key
 			'Filename': '${filename}', // adding this to keep consistency across the runtimes
 			'acl': 'public-read',
-			'Content-Type': 'image/jpeg',
-			'success_action_status': '201',
+			'Content-Type': 'image/jpeg'
 			'AWSAccessKeyId' : '<?php echo $accessKeyId; ?>',		
 			'policy': '<?php echo $policy; ?>',
 			'signature': '<?php echo $signature; ?>'


### PR DESCRIPTION
Amazon was returning "403 Forbidden - Invalid Field: success_action_status" when I tried this example.  Removing that field made it work.  Maybe they changed something.
