### PR TITLE
Example s3.php:: Updated multipart_params to match policy

### DIFF
--- a/examples/jquery/s3.php
+++ b/examples/jquery/s3.php
@@ -98,7 +98,8 @@ $(function() {
 			'Content-Type': 'image/jpeg',
 			'AWSAccessKeyId' : '<?php echo $accessKeyId; ?>',		
 			'policy': '<?php echo $policy; ?>',
-			'signature': '<?php echo $signature; ?>'
+			'signature': '<?php echo $signature; ?>',
+			'success_action_status': '201'
 		},
 		
 		// !!!Important!!! 


### PR DESCRIPTION
I found when trying out the example code in s3.php that the upload fails when the policy object and multipart_params are different. This code didn't work for me until I added "'success_action_status': '201'" to multipart_params in the plupload object creation call.
