### PR TITLE
added period to fix plupload_message class name

### DIFF
--- a/js/jquery.ui.plupload/css/jquery.ui.plupload.css
+++ b/js/jquery.ui.plupload/css/jquery.ui.plupload.css
@@ -336,7 +336,7 @@
 	font-weight: bold;	
 }
 
-plupload_message i {
+.plupload_message i {
 	font-style: italic;	
 }
 


### PR DESCRIPTION
There was a period missing before the plupload_message class name in the CSS
