### PR TITLE
Set status to DONE before firing UploadProgress

### DIFF
--- a/src/plupload.js
+++ b/src/plupload.js
@@ -1434,9 +1434,9 @@ plupload.Uploader = function(options) {
 						blob = null;
 					}
 
-					up.trigger('UploadProgress', file);
-
 					file.status = plupload.DONE;
+
+					up.trigger('UploadProgress', file);
 
 					up.trigger('FileUploaded', file, {
 						response : xhr.responseText,


### PR DESCRIPTION
It is better to set the file status to plupload.DONE before firing UploadProgress, because if a listener listening to the event wants to distinguish between "the browser has sent all the data to the server" and "the server has accepted the file and processed it", then it is important to know that status.

Example: In my application, files get encrypted after they are uploaded. With big files, this takes some time, so in my user interface, I say "Encrypting..." when the browser has sent all the data to the server, and "Done" or "100 %" after the server responds. Otherwise, users might get irritated when it says "100 %" and the UI is stuck.
