### PR TITLE
Added callback before chunk upload. Allows async operations before continue

### DIFF
--- a/src/plupload.js
+++ b/src/plupload.js
@@ -1484,6 +1484,12 @@ plupload.Uploader = function(options) {
 
 
 			function continueUpload(skipChunk) {
+
+				// Check if file or upload cancelled
+				if (file.status !== plupload.UPLOADING || up.state === plupload.STOPPED) {
+					return;
+				}
+
 				// Build multipart request
 
 				if(skipChunk) { //skip this chunk

--- a/src/plupload.js
+++ b/src/plupload.js
@@ -1499,6 +1499,7 @@ plupload.Uploader = function(options) {
 				else{
 
 					if (up.settings.multipart && features.multipart) {
+						url = up.settings.url;
 						xhr.open("post", url, true);
 
 						// Set custom headers

--- a/src/plupload.js
+++ b/src/plupload.js
@@ -1490,7 +1490,6 @@ plupload.Uploader = function(options) {
 					return;
 				}
 
-				// Build multipart request
 
 				if(skipChunk) { //skip this chunk
 					xhr.status = 200; //fake ok return code


### PR DESCRIPTION
So I've added a pre-chunk upload callback. It does not use an event, instead it calls a user supplied function. The reason being is the user is allowed to continue uploading the file by calling the included parameter. This allows the user to perform async operations on the data and then continue the chunk upload when those operations finish. This is necessary for things like calculating a hash, doing server operations prior to upload, and other async activities.
