### PR TITLE
Adding some filename sanitization to example's upload.php

### DIFF
--- a/examples/upload.php
+++ b/examples/upload.php
@@ -59,8 +59,8 @@ if (isset($_REQUEST["name"])) {
 }
 
 // Sanitize file name
-$fileName = basename($filename);
-$fileName = preg_replace('/[^a-zA-Z0-9-_.]/g', '_', $fileName);
+$fileName = basename($fileName);
+$fileName = preg_replace('/[^-a-zA-Z0-9_.]/', '_', $fileName);
 $fileName = preg_replace('/^\.*/', '', $fileName);
 
 if ($fileName === "") {

--- a/examples/upload.php
+++ b/examples/upload.php
@@ -58,6 +58,15 @@ if (isset($_REQUEST["name"])) {
 	$fileName = uniqid("file_");
 }
 
+// Sanitize file name
+$fileName = basename($filename);
+$fileName = preg_replace('/[^a-zA-Z0-9-_.]/g', '_', $fileName);
+$fileName = preg_replace('/^\.*/', '', $fileName);
+
+if ($fileName === "") {
+        $fileName = uniqid("file_");
+}
+
 $filePath = $targetDir . DIRECTORY_SEPARATOR . $fileName;
 
 // Chunking might be enabled


### PR DESCRIPTION
First, get just the filename portion of the name.  One could send
`../../../../../../etc/passwd` or something crazy and we just want the
`passwd` portion.

Next, eliminate all leading periods.  That way we don't create
`.htaccess` files by accident.

Change all unsafe characters to underscore.

Finally, if that produces an empty string, we'll just make up our own
filename.