### PR TITLE
Allow PUT

### DIFF
--- a/src/plupload.js
+++ b/src/plupload.js
@@ -710,6 +710,7 @@ plupload.addFileFilter('prevent_duplicates', function(value, file, cb) {
 	@param {String} [settings.flash_swf_url] URL of the Flash swf.
 	@param {Object} [settings.headers] Custom headers to send with the upload. Hash of name/value pairs.
 	@param {Number} [settings.max_retries=0] How many times to retry the chunk or file, before triggering Error event.
+	@param {String} [settings.multipart="post"] Either post or put.
 	@param {Boolean} [settings.multipart=true] Whether to send file and additional parameters as Multipart formated message.
 	@param {Object} [settings.multipart_params] Hash of key/value pairs to send with every file upload.
 	@param {Boolean} [settings.multi_selection=true] Enable ability to select multiple files at once in file dialog.
@@ -1397,6 +1398,7 @@ plupload.Uploader = function(options) {
 		max_retries: 0,
 		max_upload_slots: 1,
 		chunk_size: 0,
+		method: 'post',
 		multipart: true,
 		multi_selection: true,
 		file_data_name: 'file',
@@ -2111,6 +2113,7 @@ plupload.File = (function() {
 			@param {Object} options
 				@param {String} options.url
 				@param {Number} options.max_retries
+				@param {Boolean} [options.method='post']
 				@param {Boolean} [options.multipart=true]
 				@param {Boolean} [options.file_data_name='file']
 				@param {Number} options.chunk_size
@@ -2123,6 +2126,7 @@ plupload.File = (function() {
 			upload: function(options) {
 
 				options = plupload.extend({
+					method: 'post',
 					multipart: true,
 					multipart_params: {},
 					headers: {},
@@ -2297,7 +2301,7 @@ plupload.File = (function() {
 
 					// Build multipart request
 					if (options.multipart && canSendMultipart) {
-						xhr.open("post", url, true);
+						xhr.open(options.method, url, true);
 
 						// Set custom headers
 						plupload.each(options.headers, function(value, name) {
@@ -2318,7 +2322,7 @@ plupload.File = (function() {
 						// if no multipart, send as binary stream
 						url = plupload.buildUrl(options.url, plupload.extend(data, options.multipart_params));
 						
-						xhr.open("post", url, true);
+						xhr.open(options.method, url, true);
 
 						xhr.setRequestHeader('Content-Type', 'application/octet-stream'); // Binary stream header
 


### PR DESCRIPTION
Adds an option to PUT instead of POST. This is required to upload to S3 with a pre-signed URL.

This workflow makes uploading to S3 much simpler, from your backend you return a single signed URL, then you just set `uploader.settings.url` to the signed URL and `uploader.method` to put, set multipart to false, and that's it!