### PR TITLE
Timeout after 90 seconds

### DIFF
--- a/src/plupload.js
+++ b/src/plupload.js
@@ -2290,6 +2290,10 @@ plupload.File = (function() {
 						handleError();
 					};
 
+					xhr.ontimeout = function() {
+						handleError();
+					};
+
 					xhr.onloadend = function() {
 						this.destroy();
 						xhr = null;
@@ -2298,6 +2302,7 @@ plupload.File = (function() {
 					// Build multipart request
 					if (options.multipart && canSendMultipart) {
 						xhr.open("post", url, true);
+						xhr.timeout = 90000;
 
 						// Set custom headers
 						plupload.each(options.headers, function(value, name) {
@@ -2319,6 +2324,7 @@ plupload.File = (function() {
 						url = plupload.buildUrl(options.url, plupload.extend(data, options.multipart_params));
 						
 						xhr.open("post", url, true);
+						xhr.timeout = 90000;
 
 						xhr.setRequestHeader('Content-Type', 'application/octet-stream'); // Binary stream header
 


### PR DESCRIPTION
When the server is busy or the request can’t be dealt with for some other reason, usually an appropriate status code is returned so that the request fails. However, occasionally, this is not the case. As a result, the request stays alive and the upload gets stuck. It is therefore vital to set a maximum time a request can take before it times out. Unfortunately, plupload doesn’t set a timeout nor has an option to.

This is referred to in my article on Medium: https://medium.com/@fourlabsldn/error-proofing-plupload-1c64ab28bed0
This was also reported as an issue before: https://github.com/moxiecode/plupload/issues/1042
