### PR TITLE
Allow chaining of bind method calls

### DIFF
--- a/src/plupload.js
+++ b/src/plupload.js
@@ -1882,6 +1882,7 @@ plupload.Uploader = function(options) {
 				args.splice(0, 1, self); // replace event object with uploader instance
 				return func.apply(this, args);
 			}, 0, scope);
+			return self;
 		},
 
 		/**


### PR DESCRIPTION
Example:

```
var uploader = new plupload.Uploader(settings);
uploader
    .bind('PostInit', function () { })
    .bind('FilesAdded', function () { });
```
