### PR TITLE
Fix for issue #1255

### DIFF
--- a/js/moxie.js
+++ b/js/moxie.js
@@ -1138,7 +1138,7 @@ define("moxie/core/utils/Env", [
 		can: can,
 		
 		browser: UAParser.browser.name,
-		version: parseFloat(UAParser.browser.major),
+		version: parseFloat(UAParser.browser.version),
 		os: UAParser.os.name, // everybody intuitively types it in a lowercase for some reason
 		osVersion: UAParser.os.version,
 


### PR DESCRIPTION
UAParser.browser.major returns NaN, this breaks the drag and drop feature in IE10+.
See also https://github.com/moxiecode/plupload/issues/1255