### PR TITLE
Attempt at resolving IE11 null reference

### DIFF
--- a/js/plupload.dev.js
+++ b/js/plupload.dev.js
@@ -1405,7 +1405,8 @@ plupload.Uploader = function(options) {
 
 			xhr.onload = function() {
 				// check if upload made itself through
-				if (xhr.status >= 400) {
+				var xhrStatus = xhr ? xhr.status : null;
+				if (xhrStatus && xhrStatus >= 400) {
 					handleError();
 					return;
 				}
@@ -1423,7 +1424,7 @@ plupload.Uploader = function(options) {
 						offset : file.loaded,
 						total : blob.size,
 						response : xhr.responseText,
-						status : xhr.status,
+						status : xhrStatus,
 						responseHeaders: xhr.getAllResponseHeaders()
 					});
 
@@ -1452,7 +1453,7 @@ plupload.Uploader = function(options) {
 
 					up.trigger('FileUploaded', file, {
 						response : xhr.responseText,
-						status : xhr.status,
+						status : xhrStatus,
 						responseHeaders: xhr.getAllResponseHeaders()
 					});
 				} else {


### PR DESCRIPTION
This is an attempt at resolving an error that can occur in IE11 in our logs. I do not yet know why it occurs, but adding a check for `null` shouldn't hurt.
