### PR TITLE
added 'BeforeChunkUpload' event

### DIFF
--- a/js/plupload.dev.js
+++ b/js/plupload.dev.js
@@ -825,6 +825,18 @@ plupload.Uploader = function(options) {
 	 */
 
 	/**
+	 * Fires when just before a chunk is uploaded. This event enables you to override settings
+	 * on the uploader instance before the chunk is uploaded.
+	 *
+	 * @event BeforeChunkUpload
+	 * @param {plupload.Uploader} uploader Uploader instance sending the event.
+	 * @param {plupload.File} file File to be uploaded.
+	 * @param {Object} POST params to be sent.
+	 * @param {Blob} current Blob.
+	 * @param {offset} current Slice offset.
+	 */
+
+	/**
 	 * Fires when a file is to be uploaded by the runtime.
 	 *
 	 * @event UploadFile
@@ -1361,7 +1373,7 @@ plupload.Uploader = function(options) {
 		}
 
 		function uploadNextChunk() {
-			var chunkBlob, formData, args = {}, curChunkSize;
+			var chunkBlob, args = {}, curChunkSize;
 
 			// make sure that file wasn't cancelled and upload is not stopped in general
 			if (file.status !== plupload.UPLOADING || up.state === plupload.STOPPED) {
@@ -1392,6 +1404,16 @@ plupload.Uploader = function(options) {
 					args.total = blob.size;
 				}
 			}
+			if(up.trigger('BeforeChunkUpload', file, args, chunkBlob, offset)){
+				up.trigger('UploadChunk', args, chunkBlob, curChunkSize);
+			}
+		}
+
+		//prevent rebind event
+		up.unbind('UploadChunk');
+		up.bind('UploadChunk', onUploadChunk);
+		function onUploadChunk(up, args, chunkBlob, curChunkSize) {
+			var formData;
 
 			xhr = new o.XMLHttpRequest();
 


### PR DESCRIPTION
added 'BeforeChunkUpload' event.
we can change POST params in 'BeforeChunkUpload' event, add file hash or something.
we can even prepare the next chunk hash in 'BeforeChunkUpload' event.

idea from #859, but that has a bug when uploading multiply files.

EXAMPLE:

```
BeforeChunkUpload: function (up, file, args, chunkBlob, offset){
    if (up.settings.hash) {
        var reader = new o.FileReader();
        reader.addEventListener('loadend', function (e) {
            crc32 = CRC32.buf(new Uint8Array(buffer));
            hash = ((crc32) >>> 0).toString(16);
            args.crc32 = hash;
            up.trigger('UploadChunk', args, chunkBlob, curChunkSize);
        });
        reader.readAsArrayBuffer(chunkBlob);
        return false; //manually trigger 'UploadChunk'
    } else {
        return true;
    }
}
```
