### PR TITLE
Fix error handling on chunk upload

### DIFF
--- a/src/plupload.js
+++ b/src/plupload.js
@@ -1509,7 +1509,7 @@ plupload.Uploader = function(options) {
 
 			xhr.onload = function() {
 				// check if upload made itself through
-				if (xhr.status < 200 && xhr.status >= 400) {
+				if (xhr.status < 200 || xhr.status >= 400) {
 					handleError();
 					return;
 				}


### PR DESCRIPTION
Since the change in commit 5538f38 (published in release 2.3.4) server errors (>= 400) no longer trigger the error handler.