### PR TITLE
Fix for inaccurate bytesPerSec after stop/start of multipart upload

### DIFF
--- a/js/plupload.dev.js
+++ b/js/plupload.dev.js
@@ -1046,7 +1046,7 @@ plupload.Uploader = function(options) {
 				loaded = file.loaded * file.origSize / file.size;
 
 				if (!file.completeTimestamp || file.completeTimestamp > startTime) {
-					loadedDuringCurrentSession += loaded;
+					loadedDuringCurrentSession += (loaded - file.progressOffset);
 				}
 
 				total.loaded += loaded;
@@ -1463,7 +1463,7 @@ plupload.Uploader = function(options) {
 
 		// make sure we start at a predictable offset
 		if (file.loaded) {
-			offset = file.loaded = chunkSize ? chunkSize * Math.floor(file.loaded / chunkSize) : 0;
+			offset = file.progressOffset = file.loaded = chunkSize ? chunkSize * Math.floor(file.loaded / chunkSize) : 0;
 		}
 
 		function handleError() {
@@ -2369,6 +2369,14 @@ plupload.File = (function() {
 			 * @type {Number}
 			 */
 			completeTimestamp: 0,
+
+			/**
+			 * Set in onUploadFile. Is used to calculate proper plupload.QueueProgress.bytesPerSec.
+			 * @private
+			 * @property progressOffset
+			 * @type {Number}
+			 */
+			progressOffset: 0,
 
 			/**
 			 * Returns native window.File object, when it's available.


### PR DESCRIPTION
When stopping/starting the uploader after a chunk has completed, `bytesPerSec` is inflated as `loadedDuringCurrentSession` includes the entire `file.loaded` value.

To replicate, start a multipart upload and stop the uploader once a chunk has completed uploading. Start the uploader again and notice `bytesPerSec` starting at a _very_ fast rate, slowly moving back to its true value.

By tracking the completed progress with `progressOffset` and using it to offset `file.loaded`, a more accurate speed can be achieved sooner.