### PR TITLE
Triggering events in Plupload

### DIFF
--- a/src/plupload.js
+++ b/src/plupload.js
@@ -2155,6 +2155,9 @@ plupload.Uploader = function(options) {
 		@param {String} name Event name to fire.
 		@param {Object..} Multiple arguments to pass along to the listener functions.
 		*/
+		trigger: function(name, Multiple) {
+			this.Uploader.prototype.__proto__.trigger(name, Multiple);
+		},
 
 		// override the parent method to match Plupload-like event logic
 		dispatchEvent: function(type) {


### PR DESCRIPTION
Attempted to add a File Filter and use the `this.trigger()` causes an error. Even using `plupload.trigger()` caused an error because the method does not exist in plupload. It exists within `plupload.Uploader.prototype.__proto__.trigger`. This PR will fix that issue so that no one else goes as crazy as I did trying to find where the trigger method is at.

Unless of course we are using an older version of Plupload . . .