### PR TITLE
Fixed progress calculation when max_upload_slots > 1

### DIFF
--- a/src/FileUploader.js
+++ b/src/FileUploader.js
@@ -106,6 +106,8 @@ define('plupload/FileUploader', [
 				chunk.start = chunk.seq * chunkSize;
 				chunk.end = Math.min(chunk.start + chunkSize, file.size);
 				chunk.total = file.size;
+				chunk.size = chunk.end - chunk.start;
+				chunk.loaded = 0;
 
 				// do not proceed for weird chunks
 				if (chunk.start < 0 || chunk.start >= file.size) {
@@ -122,7 +124,8 @@ define('plupload/FileUploader', [
 				up = new ChunkUploader(file.slice(chunk.start, chunk.end, file.type));
 
 				up.bind('progress', function(e) {
-					self.progress(calcProcessed() + e.loaded, file.size);
+					_chunks.get(chunk.seq).loaded = e.loaded;
+					self.progress(calcProcessed(), file.size);
 				});
 
 				up.bind('failed', function(e, result) {
@@ -186,7 +189,9 @@ define('plupload/FileUploader', [
 
 			_chunks.each(function(item) {
 				if (item.state === Queueable.DONE) {
-					processed += (item.end - item.start);
+					processed += item.size;
+				} else {
+					processed += item.loaded;
 				}
 			});
 


### PR DESCRIPTION
This fixes the issue where the file progress would jump back and forth as only completed chunks were included in the calculation. It also fixes the total progress which would not include the last chunk.

The fix adds a _loaded_ parameter to the chunk data structure. The _loaded_ value is updated on each _process_ event. When the progress is calculated the _loaded_ value of each processing chunk is added with the size of the completed chunks.
A _size_ parameter is also added to the chunk structure. This is used on completed chunks instead of calculating it on every event.