### PR TITLE
docs: Fix simple typo, resizng -> resizing

### DIFF
--- a/js/jquery.plupload.queue/jquery.plupload.queue.js
+++ b/js/jquery.plupload.queue/jquery.plupload.queue.js
@@ -60,7 +60,7 @@ used as it is.
 	@param {Boolean} [settings.multi_selection=true] Enable ability to select multiple files at once in file dialog.
 	@param {Boolean} [settings.prevent_duplicates=false] Do not let duplicates into the queue. Dispatches `plupload.FILE_DUPLICATE_ERROR`.
 	@param {String|Object} [settings.required_features] Either comma-separated list or hash of required features that chosen runtime should absolutely possess.
-	@param {Object} [settings.resize] Enable resizng of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
+	@param {Object} [settings.resize] Enable resizing of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
 		@param {Number} [settings.resize.width] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.height] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.quality=90] Compression quality for jpegs (1-100).

--- a/js/jquery.ui.plupload/jquery.ui.plupload.js
+++ b/js/jquery.ui.plupload/jquery.ui.plupload.js
@@ -89,7 +89,7 @@ _jQuery UI_ widget factory, there are some specifics. See examples below for mor
 	@param {Boolean} [settings.multi_selection=true] Enable ability to select multiple files at once in file dialog.
 	@param {Boolean} [settings.prevent_duplicates=false] Do not let duplicates into the queue. Dispatches `plupload.FILE_DUPLICATE_ERROR`.
 	@param {String|Object} [settings.required_features] Either comma-separated list or hash of required features that chosen runtime should absolutely possess.
-	@param {Object} [settings.resize] Enable resizng of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
+	@param {Object} [settings.resize] Enable resizing of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
 		@param {Number} [settings.resize.width] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.height] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.quality=90] Compression quality for jpegs (1-100).

--- a/js/plupload.dev.js
+++ b/js/plupload.dev.js
@@ -796,7 +796,7 @@ plupload.addFileFilter('prevent_empty', function(value, file, cb) {
 	@param {Object} [settings.multipart_params] Hash of key/value pairs to send with every file upload.
 	@param {Boolean} [settings.multi_selection=true] Enable ability to select multiple files at once in file dialog.
 	@param {String|Object} [settings.required_features] Either comma-separated list or hash of required features that chosen runtime should absolutely possess.
-	@param {Object} [settings.resize] Enable resizng of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
+	@param {Object} [settings.resize] Enable resizing of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
 		@param {Number} [settings.resize.width] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.height] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.quality=90] Compression quality for jpegs (1-100).

--- a/src/jquery.plupload.queue/jquery.plupload.queue.js
+++ b/src/jquery.plupload.queue/jquery.plupload.queue.js
@@ -60,7 +60,7 @@ used as it is.
 	@param {Boolean} [settings.multi_selection=true] Enable ability to select multiple files at once in file dialog.
 	@param {Boolean} [settings.prevent_duplicates=false] Do not let duplicates into the queue. Dispatches `plupload.FILE_DUPLICATE_ERROR`.
 	@param {String|Object} [settings.required_features] Either comma-separated list or hash of required features that chosen runtime should absolutely possess.
-	@param {Object} [settings.resize] Enable resizng of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
+	@param {Object} [settings.resize] Enable resizing of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
 		@param {Number} [settings.resize.width] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.height] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.quality=90] Compression quality for jpegs (1-100).

--- a/src/jquery.ui.plupload/jquery.ui.plupload.js
+++ b/src/jquery.ui.plupload/jquery.ui.plupload.js
@@ -89,7 +89,7 @@ _jQuery UI_ widget factory, there are some specifics. See examples below for mor
 	@param {Boolean} [settings.multi_selection=true] Enable ability to select multiple files at once in file dialog.
 	@param {Boolean} [settings.prevent_duplicates=false] Do not let duplicates into the queue. Dispatches `plupload.FILE_DUPLICATE_ERROR`.
 	@param {String|Object} [settings.required_features] Either comma-separated list or hash of required features that chosen runtime should absolutely possess.
-	@param {Object} [settings.resize] Enable resizng of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
+	@param {Object} [settings.resize] Enable resizing of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
 		@param {Number} [settings.resize.width] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.height] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.quality=90] Compression quality for jpegs (1-100).

--- a/src/plupload.js
+++ b/src/plupload.js
@@ -769,7 +769,7 @@ plupload.addFileFilter('prevent_empty', function(value, file, cb) {
 	@param {Object} [settings.multipart_params] Hash of key/value pairs to send with every file upload.
 	@param {Boolean} [settings.multi_selection=true] Enable ability to select multiple files at once in file dialog.
 	@param {String|Object} [settings.required_features] Either comma-separated list or hash of required features that chosen runtime should absolutely possess.
-	@param {Object} [settings.resize] Enable resizng of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
+	@param {Object} [settings.resize] Enable resizing of images on client-side. Applies to `image/jpeg` and `image/png` only. `e.g. {width : 200, height : 200, quality : 90, crop: true}`
 		@param {Number} [settings.resize.width] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.height] If image is bigger, it will be resized.
 		@param {Number} [settings.resize.quality=90] Compression quality for jpegs (1-100).


### PR DESCRIPTION
There is a small typo in js/jquery.plupload.queue/jquery.plupload.queue.js, js/jquery.ui.plupload/jquery.ui.plupload.js, js/plupload.dev.js, src/jquery.plupload.queue/jquery.plupload.queue.js, src/jquery.ui.plupload/jquery.ui.plupload.js, src/plupload.js.

Should read `resizing` rather than `resizng`.

