### PR TITLE
Fixed extList2mimes function where mimes was used and overriden at the same time

### DIFF
--- a/js/moxie.js
+++ b/js/moxie.js
@@ -3471,7 +3471,7 @@ define("moxie/core/utils/Mime", [
 
 
 	var extList2mimes = function (filters, addMissingExtensions) {
-		var ext, i, ii, type, mimes = [];
+		var ext, i, ii, type, mimes_ = [];
 
 		// convert extensions to mime types list
 		for (i = 0; i < filters.length; i++) {
@@ -3488,16 +3488,17 @@ define("moxie/core/utils/Mime", [
 
 				// future browsers should filter by extension, finally
 				if (addMissingExtensions && /^\w+$/.test(ext[ii])) {
-					mimes.push('.' + ext[ii]);
-				} else if (type && Basic.inArray(type, mimes) === -1) {
-					mimes.push(type);
+					mimes_.push('.' + ext[ii]);
+				} else if (type && Basic.inArray(type, mimes_) === -1) {
+					mimes_.push(type);
 				} else if (!type) {
 					// if we have no type in our map, then accept all
 					return [];
 				}
 			}
 		}
-		return mimes;
+
+		return mimes_;
 	};
 
 


### PR DESCRIPTION
This is a quick fix to the extList2mimes function (which is not very useful, but anyway): in this function, the `mimes` variable declared above in the code is used with `mimes[ext[ii]]`, but is also overridden locally with the same name. This make the `type` variable never correctly filled and the code failing to fill the mimes when needed. This PR fixes it.