### PR TITLE
Added iOS safari to the filter_by_extension test

### DIFF
--- a/js/moxie.js
+++ b/js/moxie.js
@@ -6823,7 +6823,8 @@ define("moxie/runtime/html5/Runtime", [
 						(Env.browser === 'Chrome' && Env.verComp(Env.version, 28, '<')) || 
 						(Env.browser === 'IE' && Env.verComp(Env.version, 10, '<')) || 
 						(Env.browser === 'Safari' && Env.verComp(Env.version, 7, '<')) ||
-						(Env.browser === 'Firefox' && Env.verComp(Env.version, 37, '<'))
+						(Env.browser === 'Firefox' && Env.verComp(Env.version, 37, '<')) ||
+						(Env.browser === 'Mobile Safari' && Env.os === 'iOS')
 					);
 				}()),
 				return_response_headers: True,


### PR DESCRIPTION
This PR enhances the filter_by_extension test so that Safari on iOS is provided with an accept attribute with mime types instead of extensions, as it is one of the rare tricky browsers no accepting extensions (see: https://caniuse.com/input-file-accept)